### PR TITLE
add cli extend to extend the sector expiration

### DIFF
--- a/chain/actors/policy/policy.go
+++ b/chain/actors/policy/policy.go
@@ -22,6 +22,7 @@ import (
 	miner3 "github.com/filecoin-project/specs-actors/v3/actors/builtin/miner"
 	paych3 "github.com/filecoin-project/specs-actors/v3/actors/builtin/paych"
 	verifreg3 "github.com/filecoin-project/specs-actors/v3/actors/builtin/verifreg"
+	"golang.org/x/xerrors"
 )
 
 const (
@@ -144,7 +145,7 @@ func GetWinningPoStSectorSetLookback(nwVer network.Version) abi.ChainEpoch {
 }
 
 func GetMaxSectorExpirationExtension() abi.ChainEpoch {
-	return miner0.MaxSectorExpirationExtension
+	return miner3.MaxSectorExpirationExtension
 }
 
 // TODO: we'll probably need to abstract over this better in the future.
@@ -173,4 +174,44 @@ func GetDefaultSectorSize() abi.SectorSize {
 	})
 
 	return szs[0]
+}
+func GetAddressedSectorsMax(nwVer network.Version) (int, error) {
+	v := actors.VersionForNetwork(nwVer)
+
+	switch v {
+
+	case actors.Version0:
+		return miner0.AddressedSectorsMax, nil
+
+	case actors.Version2:
+		return miner2.AddressedSectorsMax, nil
+
+	case actors.Version3:
+		return miner3.AddressedSectorsMax, nil
+
+	default:
+		return 0, xerrors.Errorf("unsupported network version")
+	}
+}
+
+func GetDeclarationsMax(nwVer network.Version) (int, error) {
+	v := actors.VersionForNetwork(nwVer)
+	switch v {
+
+	case actors.Version0:
+
+		// TODO: Should we instead error here since the concept doesn't exist yet?
+		return miner0.AddressedPartitionsMax, nil
+
+	case actors.Version2:
+
+		return miner2.DeclarationsMax, nil
+
+	case actors.Version3:
+
+		return miner3.DeclarationsMax, nil
+
+	default:
+		return 0, xerrors.Errorf("unsupported network version")
+	}
 }

--- a/cmd/lotus-storage-miner/sectors.go
+++ b/cmd/lotus-storage-miner/sectors.go
@@ -22,8 +22,11 @@ import (
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/lib/tablewriter"
 
+	"github.com/filecoin-project/go-bitfield"
+	"github.com/filecoin-project/lotus/chain/actors"
 	lcli "github.com/filecoin-project/lotus/cli"
 	sealing "github.com/filecoin-project/lotus/extern/storage-sealing"
+	miner3 "github.com/filecoin-project/specs-actors/v3/actors/builtin/miner"
 )
 
 var sectorsCmd = &cli.Command{
@@ -40,6 +43,7 @@ var sectorsCmd = &cli.Command{
 		sectorsStartSealCmd,
 		sectorsSealDelayCmd,
 		sectorsCapacityCollateralCmd,
+		sectorsExtendCmd,
 	},
 }
 
@@ -596,6 +600,191 @@ var sectorsUpdateCmd = &cli.Command{
 		}
 
 		return nodeApi.SectorsUpdate(ctx, abi.SectorNumber(id), api.SectorState(cctx.Args().Get(1)))
+	},
+}
+var sectorsExtendCmd = &cli.Command{
+	Name:      "extend",
+	Usage:     "Extend sector expiration",
+	ArgsUsage: "<sectorNumbers...>",
+	Flags: []cli.Flag{
+		&cli.Int64Flag{
+			Name:     "new-expiration",
+			Usage:    "new expiration epoch",
+			Required: false,
+		},
+		&cli.BoolFlag{
+			Name:     "allsectors",
+			Usage:    "renews all sectors up to the maximum possible lifetime",
+			Required: false,
+		},
+	},
+	Action: func(cctx *cli.Context) error {
+
+		api, mCloser, err := lcli.GetStorageMinerAPI(cctx)
+		if err != nil {
+			return err
+		}
+		nApi, nCloser, err := lcli.GetFullNodeAPI(cctx)
+		if err != nil {
+			return err
+		}
+
+		defer mCloser()
+		defer nCloser()
+
+		ctx := lcli.ReqContext(cctx)
+
+		maddr, err := getActorAddress(ctx, api, cctx.String("actor"))
+		if err != nil {
+			return err
+		}
+
+		var params []miner3.ExtendSectorExpirationParams
+
+		if cctx.Bool("allsectors") {
+
+			nv, err := nApi.StateNetworkVersion(ctx, types.EmptyTSK)
+			if err != nil {
+				return err
+			}
+
+			extensions := map[miner.SectorLocation]map[abi.ChainEpoch][]uint64{}
+
+			sis, err := nApi.StateMinerActiveSectors(ctx, maddr, types.EmptyTSK)
+			if err != nil {
+				return xerrors.Errorf("getting miner sector infos: %w", err)
+			}
+
+			for _, si := range sis {
+
+				ml := policy.GetMaxSectorExpirationExtension()
+
+				newExp := ml - (miner3.WPoStProvingPeriod * 2) + si.Activation
+
+				p, err := nApi.StateSectorPartition(ctx, maddr, si.SectorNumber, types.EmptyTSK)
+				if err != nil {
+					return xerrors.Errorf("getting sector location for sector %d: %w", si.SectorNumber, err)
+				}
+
+				if p == nil {
+					return xerrors.Errorf("sector %d not found in any partition", si.SectorNumber)
+				}
+
+				es, found := extensions[*p]
+				if !found {
+					ne := make(map[abi.ChainEpoch][]uint64)
+					ne[newExp] = []uint64{uint64(si.SectorNumber)}
+					extensions[*p] = ne
+				} else {
+					es[newExp] = []uint64{uint64(si.SectorNumber)}
+				}
+			}
+
+			p := miner3.ExtendSectorExpirationParams{}
+			scount := 0
+
+			for l, exts := range extensions {
+				for newExp, numbers := range exts {
+					scount += len(numbers)
+					addressedMax, err := policy.GetAddressedSectorsMax(nv)
+					if err != nil {
+						return xerrors.Errorf("failed to get addressed sectors max")
+					}
+					declMax, err := policy.GetDeclarationsMax(nv)
+					if err != nil {
+						return xerrors.Errorf("failed to get declarations max")
+					}
+					if scount > addressedMax || len(p.Extensions) == declMax {
+						params = append(params, p)
+						p = miner3.ExtendSectorExpirationParams{}
+						scount = len(numbers)
+					}
+
+					p.Extensions = append(p.Extensions, miner3.ExpirationExtension{
+						Deadline:      l.Deadline,
+						Partition:     l.Partition,
+						Sectors:       bitfield.NewFromSet(numbers),
+						NewExpiration: newExp,
+					})
+				}
+			}
+
+			// if we have any sectors, then one last append is needed here
+			if scount != 0 {
+				params = append(params, p)
+			}
+
+		} else {
+			if !cctx.Args().Present() || !cctx.IsSet("new-expiration") {
+				return xerrors.Errorf("must pass at least one sector number and new expiration")
+			}
+			sectors := map[miner.SectorLocation][]uint64{}
+
+			for i, s := range cctx.Args().Slice() {
+				id, err := strconv.ParseUint(s, 10, 64)
+				if err != nil {
+					return xerrors.Errorf("could not parse sector %d: %w", i, err)
+				}
+
+				p, err := nApi.StateSectorPartition(ctx, maddr, abi.SectorNumber(id), types.EmptyTSK)
+				if err != nil {
+					return xerrors.Errorf("getting sector location for sector %d: %w", id, err)
+				}
+
+				if p == nil {
+					return xerrors.Errorf("sector %d not found in any partition", id)
+				}
+
+				sectors[*p] = append(sectors[*p], id)
+			}
+
+			p := miner3.ExtendSectorExpirationParams{}
+			for l, numbers := range sectors {
+
+				// TODO: Dedup with above loop
+				p.Extensions = append(p.Extensions, miner3.ExpirationExtension{
+					Deadline:      l.Deadline,
+					Partition:     l.Partition,
+					Sectors:       bitfield.NewFromSet(numbers),
+					NewExpiration: abi.ChainEpoch(cctx.Int64("new-expiration")),
+				})
+			}
+
+			params = append(params, p)
+		}
+
+		if len(params) == 0 {
+			fmt.Println("nothing to extend")
+			return nil
+		}
+
+		mi, err := nApi.StateMinerInfo(ctx, maddr, types.EmptyTSK)
+		if err != nil {
+			return xerrors.Errorf("getting miner info: %w", err)
+		}
+
+		for i := range params {
+			sp, aerr := actors.SerializeParams(&params[i])
+			if aerr != nil {
+				return xerrors.Errorf("serializing params: %w", err)
+			}
+
+			smsg, err := nApi.MpoolPushMessage(ctx, &types.Message{
+				From:   mi.Worker,
+				To:     maddr,
+				Method: miner.Methods.ExtendSectorExpiration,
+
+				Value:  big.Zero(),
+				Params: sp,
+			}, nil)
+			if err != nil {
+				return xerrors.Errorf("mpool push message: %w", err)
+			}
+
+			fmt.Println(smsg.Cid())
+		}
+
+		return nil
 	},
 }
 


### PR DESCRIPTION
You can extend your sectors many times,
but every time expiration can neither be less than 180 days after activation,
nor be more than 540 days from current epoch.
Total sector lifetime cannot exceed 5 years for the sector's seal proof.